### PR TITLE
Improves exenv detection (closes #1)

### DIFF
--- a/exenv.fish
+++ b/exenv.fish
@@ -2,8 +2,8 @@
 #   exenv [options]
 #
 function init --on-event init_exenv
-  if not available exenv
-    echo "Please install 'exenv' first!"; return 1
+  if not type --quiet "exenv"
+    echo "WARNING: you loaded the fish-shell plugin for exenv, but exenv is not installed."
   end
   if status --is-interactive
     if exenv init - | grep --quiet "function"


### PR DESCRIPTION
Not using the `available` statement anymore, because it is deprecated.

Doesn’t stop the fish-shell loading workflow when exenv is not
installed. Or other words: oh-my-fish will not stop loading if exenv is
not available, for example.

Also some “refactoring” for the warning message when exenv is not
installed.
